### PR TITLE
Fix jump page callbacks

### DIFF
--- a/autolabel_gui.py
+++ b/autolabel_gui.py
@@ -1326,8 +1326,11 @@ def jump_frame_frame_by_frame_callback():
     new_frame_index = st.session_state.jump_page
     # Compare it with the current frame_index in session_state
     if st.session_state.frame_index != new_frame_index:
+        st.session_state.prev_out = None
+        st.session_state.detection_modified = False
         st.session_state.frame_index = new_frame_index
         st.session_state["skip_label_update"] = True
+        save_session_state(st.session_state.paths['session_state_path'])
 
 def jump_frame_object_by_object_callback():
     # Get the desired frame number from the number input.
@@ -1377,6 +1380,7 @@ def jump_frame_object_by_object_callback():
         st.session_state.global_object_index = global_index
         st.session_state.object_by_object_jump_valid = True
         st.session_state.object_by_object_jump_warning = None  # Set flag to trigger rerun outside callback.
+        save_session_state(st.session_state.paths['session_state_path'])
     else:
         
         st.session_state.object_by_object_jump_valid = False


### PR DESCRIPTION
## Summary
- fix jump page callback to clear state and persist frame change
- save state when jumping to a frame in object-by-object mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431224f8f88330a01072f021f20ec6