### PR TITLE
Add multi-user login script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,15 @@ cd AutoLabelEngine
 # 2. (Optional) create the project virtual-env
 bash scripts/setup_venv.sh                     # creates ./envs/auto-label-engine
 
-# 3. Launch the full GUI & helpers
-bash run_autolabel_engine.sh           # <— main entry-point
+# 3. Start the multi-user login page
+bash run_login.sh                      # spawns per-user GUI sessions
 ```
 
-`run_autolabel_engine.sh` does the following:
+`run_login.sh` does the following:
 
-1. Activates the project venv (or prompts you to generate one).  
-2. Exports permissive `umask 000` so every file created by the GUI is world-writable (helpful on multi-user servers).  
-3. Starts the Streamlit app (`autolabel_gui.py`) on **localhost:8501** and opens your browser.  
-4. Spins up a **tmux** session so all long-running jobs stay alive even if you close the browser tab.
+1. Activates the project venv (or prompts you to generate one).
+2. Launches the Streamlit login page (`login.py`) on **localhost:8501** (and optional ngrok tunnel).
+3. After a user logs in, a new **tmux** session is created running `autolabel_gui.py` on its own port.
 
 ---
 
@@ -49,8 +48,9 @@ Repeat steps 3-6 until the detector reaches your desired precision.
 ```text
 AutoLabelEngine/
 │
-├─ run_autolabel_engine.sh      # main launcher (see above)
-├─ autolabel_gui.py             # Streamlit GUI
+├─ run_login.sh                # login page entry-point
+├─ run_autolabel_gui.sh        # original single-user launcher
+├─ autolabel_gui.py            # Streamlit GUI
 ├─ cfgs/                        # YAML configs (GUI, YOLO data/model/train)
 ├─ scripts/                     # helper Python/Bash utilities
 │   ├─ convert_mp4_2_png.py

--- a/login.py
+++ b/login.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import re
+import socket
+import subprocess
+import time
+
+
+import streamlit as st
+
+
+def sanitize_username(name: str) -> str:
+    """Return a safe version of the username for filesystem usage."""
+    return re.sub(r"[^0-9A-Za-z_-]", "_", name.strip()).lower()
+
+
+def find_free_port(start: int = 8600, end: int = 8700) -> int:
+    """Find an available TCP port in the given range."""
+    for port in range(start, end):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            if s.connect_ex(("127.0.0.1", port)) != 0:
+                return port
+    raise RuntimeError("No free port available")
+
+
+def start_session(username: str) -> int:
+    """Launch autolabel_gui.py in a new tmux session and return its port."""
+    safe = sanitize_username(username)
+    session = f"ale_{safe}"
+    port = find_free_port()
+    cmd = (
+        f"streamlit run --server.headless True --server.fileWatcherType none "
+        f"--server.port {port} autolabel_gui.py"
+    )
+    subprocess.check_call(["tmux", "new-session", "-d", "-s", session, cmd])
+    return port
+
+
+st.title("AutoLabelEngine Login")
+user = st.text_input("Username")
+if st.button("Start Session"):
+    if not user.strip():
+        st.error("Please enter a username")
+    else:
+        try:
+            port = start_session(user)
+            st.success(f"Session started for {user} on port {port}.")
+            st.write(f"Open http://<server-ip>:{port} in a new tab.")
+        except Exception as e:
+            st.error(f"Failed to start session: {e}")

--- a/run_login.sh
+++ b/run_login.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+DEFAULT_VENV_PATH="../envs/auto-label-engine"
+VENV_PATH="$DEFAULT_VENV_PATH"
+
+# Kill existing ngrok processes if ngrok is installed
+if command -v ngrok >/dev/null; then
+    if pgrep -x ngrok >/dev/null; then
+        echo "Killing existing ngrok processes..."
+        pkill -f ngrok
+    fi
+fi
+
+# Ensure virtual environment exists
+if [ ! -f "$VENV_PATH/bin/activate" ]; then
+    echo "Virtual environment not found."
+    read -p "Would you like to generate it? (y/n): " generate_choice
+    if [[ ! "$generate_choice" =~ ^[Yy]$ ]]; then
+        echo "Exiting without generating virtual environment."
+        exit 1
+    fi
+    while true; do
+        read -p "Enter the directory for the virtual environment [default: $DEFAULT_VENV_PATH]: " input_path
+        if [ -z "$input_path" ]; then
+            input_path="$DEFAULT_VENV_PATH"
+        fi
+        read -p "You entered '$input_path'. Is this correct? (y/n): " confirm_choice
+        if [[ "$confirm_choice" =~ ^[Yy]$ ]]; then
+            VENV_PATH="$input_path"
+            break
+        else
+            echo "Let's try again."
+        fi
+    done
+    echo "Setting up virtual environment at '$VENV_PATH'..."
+    bash scripts/setup_venv.sh "$VENV_PATH"
+fi
+
+source "$VENV_PATH/bin/activate"
+
+STREAMLIT_PORT=8501
+
+echo "Starting login server on port $STREAMLIT_PORT..."
+streamlit run --server.headless True --server.fileWatcherType none \
+    --server.port $STREAMLIT_PORT login.py &
+STREAMLIT_PID=$!
+
+if command -v ngrok >/dev/null; then
+    echo "Starting ngrok tunnel..."
+    ngrok http $STREAMLIT_PORT --log=stdout > ngrok_login.log &
+    NGROK_PID=$!
+    sleep 2
+    echo "Your public ngrok URL is:"
+    curl --silent http://127.0.0.1:4040/api/tunnels \
+      | python3 -c "import sys,json; print(json.load(sys.stdin)['tunnels'][0]['public_url'])"
+else
+    echo "ngrok not installed—running Streamlit locally only."
+fi
+
+wait $STREAMLIT_PID
+[ -n "$NGROK_PID" ] && wait $NGROK_PID


### PR DESCRIPTION
## Summary
- add a simple `login.py` Streamlit app that launches a personal tmux session running `autolabel_gui.py`
- provide `run_login.sh` script to start the login page and ngrok tunnel
- document new workflow and entry point in README

## Testing
- `python3 -m py_compile login.py`
- `bash -n run_login.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684373211b7483308070d9ddb3edeadc