### PR TITLE
Improve frictionless login

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ bash run_login.sh                      # spawns per-user GUI sessions
 1. Activates the project venv (or prompts you to generate one).
 2. Launches the Streamlit login page (`login.py`) on **localhost:8501** (and optional ngrok tunnel).
 3. After a user logs in, a new **tmux** session is created running `autolabel_gui.py` on its own port.
+4. The new session URL is opened in a browser tab automatically using the server's IP. Set `AUTO_LABEL_BASE_URL` to override the host.
+   Each session forwards the username to the GUI so any datasets you upload are prefixed with that name.
 
 ---
 

--- a/autolabel_gui.py
+++ b/autolabel_gui.py
@@ -17,6 +17,7 @@ import hashlib
 import uuid
 import sys
 import io
+import argparse
 
 ## Third-Party Libraries 
 import math
@@ -39,6 +40,16 @@ from streamlit_label_kit import detection as _orig_detection
 from streamlit_ace import st_ace
 import streamlit.components.v1 as components
 
+
+# ----------------------------------------------------------------------------
+# CLI Args / Environment
+# ----------------------------------------------------------------------------
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("--user", default=os.environ.get("AUTO_LABEL_USER", ""))
+args, _ = parser.parse_known_args()
+AUTO_LABEL_USER = args.user or os.environ.get("AUTO_LABEL_USER", "")
+if AUTO_LABEL_USER:
+    os.environ["AUTO_LABEL_USER"] = AUTO_LABEL_USER
 
 #-------------------------------------------------------------------------------------------------------------------------#
 ## Functions
@@ -2568,8 +2579,10 @@ if "session_running" not in st.session_state:
 
     st.session_state["reset_grid"] = False
 
-    st.session_state.user_prefix = ""
-    st.session_state.edit_prefix = True
+    default_user = sanitize_username(os.environ.get("AUTO_LABEL_USER", ""))
+    st.session_state.user_prefix = default_user
+    st.session_state.allow_name_edit = not bool(default_user)
+    st.session_state.edit_prefix = not bool(default_user)
     st.session_state.user_prefix_input = ""
     st.session_state.prefix_changed = False
 
@@ -2735,14 +2748,17 @@ if st.session_state.edit_prefix:
 else:
     # Display greeting and edit button
     display_name = " ".join(w.capitalize() for w in st.session_state.user_prefix.split('_'))
-    col1, col2, _ = st.sidebar.columns([0.2, 0.7, 0.1])
-    col1.button(
-        "✏️",
-        key="change_prefix",
-        help="Change name",
-        on_click=start_edit,
-    )
-    col2.markdown(f"### 👋 Hello, **{display_name}**")
+    if st.session_state.allow_name_edit:
+        col1, col2, _ = st.sidebar.columns([0.2, 0.7, 0.1])
+        col1.button(
+            "✏️",
+            key="change_prefix",
+            help="Change name",
+            on_click=start_edit,
+        )
+        col2.markdown(f"### 👋 Hello, **{display_name}**")
+    else:
+        st.sidebar.markdown(f"### 👋 Hello, **{display_name}**")
     
     navigation_menu_margin = 375
 

--- a/login.py
+++ b/login.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import re
+import os
 import socket
 import subprocess
 import time
@@ -22,17 +23,50 @@ def find_free_port(start: int = 8600, end: int = 8700) -> int:
     raise RuntimeError("No free port available")
 
 
-def start_session(username: str) -> int:
-    """Launch autolabel_gui.py in a new tmux session and return its port."""
+def get_network_ip() -> str:
+    """Best-effort attempt to obtain the machine's LAN IP."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+    except Exception:
+        ip = "127.0.0.1"
+    finally:
+        s.close()
+    return ip
+
+
+def start_session(username: str) -> tuple[int, str]:
+    """Launch autolabel_gui.py in a new tmux session and return (port, url)."""
     safe = sanitize_username(username)
     session = f"ale_{safe}"
     port = find_free_port()
+    log = f"/tmp/{session}.log"
     cmd = (
         f"streamlit run --server.headless True --server.fileWatcherType none "
-        f"--server.port {port} autolabel_gui.py"
+        f"--server.port {port} autolabel_gui.py -- --user {safe} > {log} 2>&1"
     )
     subprocess.check_call(["tmux", "new-session", "-d", "-s", session, cmd])
-    return port
+
+    url = None
+    for _ in range(40):
+        if os.path.exists(log):
+            text = open(log).read()
+            m = re.search(r"Network URL:\s*(https?://[^\s]+)", text)
+            if m:
+                url = m.group(1)
+                break
+        time.sleep(0.5)
+
+    if not url:
+        base = os.environ.get("AUTO_LABEL_BASE_URL")
+        if not base:
+            base = get_network_ip()
+        if not base.startswith("http"):
+            base = "http://" + base
+        url = f"{base}:{port}"
+
+    return port, url
 
 
 st.title("AutoLabelEngine Login")
@@ -42,8 +76,9 @@ if st.button("Start Session"):
         st.error("Please enter a username")
     else:
         try:
-            port = start_session(user)
+            port, url = start_session(user)
             st.success(f"Session started for {user} on port {port}.")
-            st.write(f"Open http://<server-ip>:{port} in a new tab.")
+            st.markdown(f"<script>window.open('{url}', '_blank');</script>", unsafe_allow_html=True)
+            st.write(f"Opened {url} in a new tab.")
         except Exception as e:
             st.error(f"Failed to start session: {e}")


### PR DESCRIPTION
## Summary
- open each AutoLabelEngine session in a new browser tab automatically
- pass `--user` from login page and expose `AUTO_LABEL_USER`
- hide the change-name prompt when a user name is given
- document the automatic session launch and `AUTO_LABEL_BASE_URL`

## Testing
- `python -m py_compile login.py autolabel_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_68437e109c048330a42663926c279eb0